### PR TITLE
fix: correct root_handler initialization and evaluator typo in OCLWra…

### DIFF
--- a/bocl/OCLWrapper.py
+++ b/bocl/OCLWrapper.py
@@ -32,7 +32,8 @@ class OCLWrapper:
 
         # self.preprocess(ocl.expression)
         input_stream = InputStream(ocl.expression)
-        root_handler = Root_Handler(ocl,self.dm,self.om)
+        root_handler = Root_Handler(self.dm,self.om)
+        root_handler.set_context(ocl.context)
         lexer = BOCLLexer(input_stream)
         stream = CommonTokenStream(lexer)
         parser = BOCLParser(stream)
@@ -41,7 +42,7 @@ class OCLWrapper:
         walker = ParseTreeWalker()
         walker.walk(listener,tree)
 
-        evalualor = Evaluator()
+        evaluator = Evaluator()
 
-        return evalualor.evaluate(root_handler, self.om)
+        return evaluator.evaluate(root_handler, self.om)
         # return True


### PR DESCRIPTION
This pull request includes updates to the `evaluate` method in the `OCLWrapper.py` file, focusing on improving context handling and fixing a typo in variable naming.

Enhancements to context handling:

* [`bocl/OCLWrapper.py`](diffhunk://#diff-6703efed3c4ad285060cf6fe5edbc38c625f1aaf1c2ed390cffeb7674acd84feL35-R36):  
  Modified the initialization of `Root_Handler` to include `set_context(ocl.context)` for better handling of the OCL context.
  Fixing the Root_Handler constructor parameters.

* [`bocl/OCLWrapper.py`](diffhunk://#diff-6703efed3c4ad285060cf6fe5edbc38c625f1aaf1c2ed390cffeb7674acd84feL44-R47): Corrected a typo in the variable name from `evalualor` to `evaluator`.
